### PR TITLE
adding tolerations and nodeSelector to the csi-attacher-plugin

### DIFF
--- a/charts/volumez-csi/templates/statefulset.yaml
+++ b/charts/volumez-csi/templates/statefulset.yaml
@@ -137,3 +137,11 @@ spec:
             secretName: vlz-admission-webhook-tls
         - name: socket-dir
           emptyDir:
+{{- if .Values.csiAttacherVlzplugin.tolerations }}
+      tolerations:
+{{ toYaml .Values.csiAttacherVlzplugin.tolerations | indent 8 }}
+{{- end -}}
+{{- if .Values.csiAttacherVlzplugin.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.csiAttacherVlzplugin.nodeSelector | indent 8 }}
+{{- end -}}

--- a/charts/volumez-csi/values.yaml
+++ b/charts/volumez-csi/values.yaml
@@ -42,3 +42,9 @@ k8s:
   provisionerVer: "v3.0.0"
   snapshotter: "v5.0.1"
   snapshotController: "v4.2.1"
+
+csiAttacherVlzplugin: 
+  tolerations: 
+  nodeSelector:
+
+


### PR DESCRIPTION
Added tolerations and nodeSelector fields to the statefulset.yaml template. These values are only included if the csiAttacherVlzplugin portion of values.yaml is included and not empty