### PR TITLE
VLZ-8234: Make cert-manager sub-chart installation as configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To install the volumez-csi chart:
 helm install my-volumez-csi volumez-csi/volumez-csi -n vlz-csi-driver --create-namespace --dependency-update
 ```
 
-**If you have already cert-manager chart installed in your cluster:**
+**If you already have Cert-Manager on your cluster:**
 ```bash
 helm install my-volumez-csi volumez-csi/volumez-csi -n vlz-csi-driver --create-namespace --dependency-update --set certmanager.enabled=false
 ```

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ To install the volumez-csi chart:
 helm install my-volumez-csi volumez-csi/volumez-csi -n vlz-csi-driver --create-namespace --dependency-update
 ```
 
+**If you have already cert-manager chart installed in your cluster:**
+```bash
+helm install my-volumez-csi volumez-csi/volumez-csi -n vlz-csi-driver --create-namespace --dependency-update --set certmanager.enabled=false
+```
+
 ### Install Only on Specific Node/Node-Group
 To install the volumez-csi on specific node or nodegroup, label the node/nodegroup and add the following to the end of install command (fill in the correct values instead of "label-key" and "label-values"):
 ```bash

--- a/charts/volumez-csi/Chart.yaml
+++ b/charts/volumez-csi/Chart.yaml
@@ -10,4 +10,4 @@ dependencies:
     version: 1.11.0
     repository: https://charts.jetstack.io
     alias: certmanager
-    condition: cert-manager.enabled
+    condition: certmanager.enabled

--- a/charts/volumez-csi/templates/certmanager-namespace.yaml
+++ b/charts/volumez-csi/templates/certmanager-namespace.yaml
@@ -1,4 +1,7 @@
+{{ if .Values.certmanager.enabled }}
 apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.certmanager.namespace }}
+{{ end }}
+

--- a/charts/volumez-csi/values.yaml
+++ b/charts/volumez-csi/values.yaml
@@ -52,3 +52,4 @@ csiNodeVlzplugin:
 certmanager:
   namespace: vlz-cert-manager
   installCRDs: true
+  enabled: true


### PR DESCRIPTION
Make cert-manager sub-chart installation as configurable by the helm value bool value: cert-manager.enabled
