### PR TITLE
VLZ-10906 Allow multiple instances of CSI on shared cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /charts/volumez-csi/charts
-values.dev.yaml
+values.dev*.yaml

--- a/charts/volumez-csi/templates/clusterrole-attacher.yaml
+++ b/charts/volumez-csi/templates/clusterrole-attacher.yaml
@@ -1,8 +1,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: external-attacher-runner
-  namespace: {{ .Release.Namespace }}
+  name: external-attacher-runner{{- if .Values.multiInstanceMode }}-{{ .Release.Namespace }}{{- end }}
 rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses"]

--- a/charts/volumez-csi/templates/clusterrole-nodeplugin.yaml
+++ b/charts/volumez-csi/templates/clusterrole-nodeplugin.yaml
@@ -1,8 +1,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: csi-nodeplugin
-  namespace: {{ .Release.Namespace }}
+  name: csi-nodeplugin{{- if .Values.multiInstanceMode }}-{{ .Release.Namespace }}{{- end }}
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]

--- a/charts/volumez-csi/templates/clusterrolebinding-attacher.yaml
+++ b/charts/volumez-csi/templates/clusterrolebinding-attacher.yaml
@@ -1,12 +1,12 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: csi-attacher-role
+  name: csi-attacher-role{{- if .Values.multiInstanceMode }}-{{ .Release.Namespace }}{{- end }}
 subjects:
   - kind: ServiceAccount
     name: csi-attacher
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: external-attacher-runner
+  name: external-attacher-runner{{- if .Values.multiInstanceMode }}-{{ .Release.Namespace }}{{- end }}
   apiGroup: rbac.authorization.k8s.io

--- a/charts/volumez-csi/templates/clusterrolebinding-nodeplugin.yaml
+++ b/charts/volumez-csi/templates/clusterrolebinding-nodeplugin.yaml
@@ -1,12 +1,12 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: csi-nodeplugin
+  name: csi-nodeplugin{{- if .Values.multiInstanceMode }}-{{ .Release.Namespace }}{{- end }}
 subjects:
   - kind: ServiceAccount
     name: csi-nodeplugin
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: csi-nodeplugin
+  name: csi-nodeplugin{{- if .Values.multiInstanceMode }}-{{ .Release.Namespace }}{{- end }}
   apiGroup: rbac.authorization.k8s.io  

--- a/charts/volumez-csi/templates/csi-driver.yaml
+++ b/charts/volumez-csi/templates/csi-driver.yaml
@@ -1,7 +1,7 @@
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
-  name: vlz
+  name: vlz{{- if .Values.multiInstanceMode }}-{{ .Release.Namespace }}{{- end }}
 spec:
   attachRequired: true
   podInfoOnMount: true

--- a/charts/volumez-csi/templates/daemonset.yaml
+++ b/charts/volumez-csi/templates/daemonset.yaml
@@ -50,14 +50,15 @@ spec:
           args:
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"
-            - "--volumezendpoint=$(VOLUMEZ_ENDPOINT)"
-            - "--volumezEndpointBasePath=$(VOLUMEZ_ENDPOINT_BASE_PATH)"
-            - "--volumezauthtoken=$(VOLUMEZ_AUTH_TOKEN)"
-            - "--run_connector=$(RUN_CONNECTOR)"         
-            - "--connector_force_install=$(CONNECTOR_FORCE_INSTALL)"
-            - "--connector_download_repository_base_url=$(CONNECTOR_DOWNLOAD_REPOSITORY_BASE_URL)"
-            - "--connector_api_domain=$(CONNECTOR_API_DOMAIN)"
-            - "--env_id=$(ENV_ID)"
+            - "--volumez-endpoint=$(VOLUMEZ_ENDPOINT)"
+            - "--volumez-endpoint-base-path=$(VOLUMEZ_ENDPOINT_BASE_PATH)"
+            - "--volumez-auth-token=$(VOLUMEZ_AUTH_TOKEN)"            
+            - "--run-connector=$(RUN_CONNECTOR)"
+            - "--connector-force-install=$(CONNECTOR_FORCE_INSTALL)"
+            - "--connector-download-repository-base-url=$(CONNECTOR_DOWNLOAD_REPOSITORY_BASE_URL)"
+            - "--connector-api-domain=$(CONNECTOR_API_DOMAIN)"
+            - "--env-id=$(ENV_ID)"
+            - "--driver-suffix=$(DRIVER_NAME_SUFFIX)"
             - "--v=$(VERBOSE_LEVEL)"
           env:
             - name: NODE_ID
@@ -82,6 +83,8 @@ spec:
               value: "{{ .Values.vlzConnector.domain }}"
             - name: ENV_ID
               value: "{{ .Values.envId }}"
+            - name: DRIVER_NAME_SUFFIX
+              value: "{{- if .Values.multiInstanceMode }}{{ .Release.Namespace }}{{- end }}"
             - name: VERBOSE_LEVEL
               value: "{{ .Values.verboseLevel }}"
 

--- a/charts/volumez-csi/templates/statefulset.yaml
+++ b/charts/volumez-csi/templates/statefulset.yaml
@@ -110,14 +110,15 @@ spec:
           args :
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"
-            - "--volumezendpoint=$(VOLUMEZ_ENDPOINT)"
-            - "--volumezEndpointBasePath=$(VOLUMEZ_ENDPOINT_BASE_PATH)"
-            - "--volumezauthtoken=$(VOLUMEZ_AUTH_TOKEN)"            
-            - "--run_connector=$(RUN_CONNECTOR)"
-            - "--connector_force_install=$(CONNECTOR_FORCE_INSTALL)"
-            - "--connector_download_repository_base_url=$(connector_download_repository_base_url)"
-            - "--connector_api_domain=$(CONNECTOR_API_DOMAIN)"
-            - "--env_id=$(ENV_ID)"
+            - "--volumez-endpoint=$(VOLUMEZ_ENDPOINT)"
+            - "--volumez-endpoint-base-path=$(VOLUMEZ_ENDPOINT_BASE_PATH)"
+            - "--volumez-auth-token=$(VOLUMEZ_AUTH_TOKEN)"            
+            - "--run-connector=$(RUN_CONNECTOR)"
+            - "--connector-force-install=$(CONNECTOR_FORCE_INSTALL)"
+            - "--connector-download-repository-base-url=$(CONNECTOR_DOWNLOAD_REPOSITORY_BASE_URL)"
+            - "--connector-api-domain=$(CONNECTOR_API_DOMAIN)"
+            - "--env-id=$(ENV_ID)"
+            - "--driver-suffix=$(DRIVER_NAME_SUFFIX)"
             - "--v=$(VERBOSE_LEVEL)"
 
           env:
@@ -137,10 +138,12 @@ spec:
               value: "false"
             - name: CONNECTOR_FORCE_INSTALL
               value: "{{ .Values.vlzConnector.forceInstall }}"
-            - name: connector_download_repository_base_url
+            - name: CONNECTOR_DOWNLOAD_REPOSITORY_BASE_URL
               value: "{{ .Values.vlzConnector.repoUrl }}"
             - name: ENV_ID
               value: "{{ .Values.envId }}"
+            - name: DRIVER_NAME_SUFFIX
+              value: "{{- if .Values.multiInstanceMode }}{{ .Release.Namespace }}{{- end }}"
             - name: VERBOSE_LEVEL
               value: "{{ .Values.verboseLevel }}"
 

--- a/charts/volumez-csi/templates/validating-webhook.config.yaml
+++ b/charts/volumez-csi/templates/validating-webhook.config.yaml
@@ -1,11 +1,11 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: "vlz-admission-webhook.volumez.com"
+  name: "vlz-admission-webhook{{- if .Values.multiInstanceMode }}-{{ .Release.Namespace }}{{- end }}.volumez.com"
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/vlz-admission-webhook-serving-cert
 webhooks:
-  - name: "vlz-admission-webhook.volumez.com"
+  - name: "vlz-admission-webhook{{- if .Values.multiInstanceMode }}-{{ .Release.Namespace }}{{- end }}.volumez.com"
     rules:
       - apiGroups: ["vlzcontroller.k8s.io"]
         apiVersions: ["*"]

--- a/charts/volumez-csi/templates/webhook.svc.yaml
+++ b/charts/volumez-csi/templates/webhook.svc.yaml
@@ -16,6 +16,5 @@ spec:
     - port: 443
       protocol: TCP
       targetPort: 443
-      nodePort: 30100
   selector:
     webhook: vlz-admission-webhook

--- a/charts/volumez-csi/values.yaml
+++ b/charts/volumez-csi/values.yaml
@@ -24,6 +24,10 @@ vlzEndpoint:
 
 # CSI Driver Token (Refresh Token)
 vlzAuthToken: ""
+
+# Allows multiple deployments of the CSI driver on the same cluster
+multiInstanceMode: false
+
 verboseLevel: 0
 
 vlzConnector:


### PR DESCRIPTION
supports multiple instances of csi by adding the namespace as a suffix to the driver name.
note: update chart's app version and CSI image tag accordingly when released.