### PR TITLE
VLZ-13301 Fix helm repo update command and update example release name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Helm's [documentation](https://helm.sh/docs) to get started.
 Once Helm has been set up correctly, add the repo as follows:
 
 ```bash
-helm repo add volumez-csi https://volumeztech.github.io/helm-csi
+helm repo add volumez-csi https://volumeztech.github.io/helm-csi --force-update
 ```
 
 ### Configuration
@@ -17,49 +17,51 @@ For detailed configuration options, please refer to the [volumez-csi chart READM
 
 ### Install
 
-To install the volumez-csi chart:
+To install the `volumez-csi` chart:
 
 ```bash
-helm install my-volumez-csi volumez-csi/volumez-csi -n vlz-csi-driver --create-namespace 
+helm install volumez-csi volumez-csi/volumez-csi -n vlz-csi-driver --create-namespace 
 ```
 
 To install a specific chart version:
 ```bash
-helm install my-volumez-csi volumez-csi/volumez-csi -n vlz-csi-driver --create-namespace --version VERSION_TAG
+helm install volumez-csi volumez-csi/volumez-csi -n vlz-csi-driver --create-namespace --version VERSION_TAG
 ```
 i.e:
 ```bash
-helm install my-volumez-csi volumez-csi/volumez-csi -n vlz-csi-driver --create-namespace --version 1.22.0-rc.1
+helm install volumez-csi volumez-csi/volumez-csi -n vlz-csi-driver --create-namespace --version 1.31.0-rc.1
 ```
+<br/>
 
-To install the volumez-csi on a specific node or node group, label the node/node group and add the following to the end of the install command (fill in the correct values instead of "label-key" and "label-values"):
+To install `volumez-csi` on a specific node or node group, first label the node(s) appropriately.
+Then, add the following flag to the end of your helm install command, replacing `<label-key>` and `<label-values>` with your actual labels:
 
 ```bash
 --set-json 'csiNodeVlzplugin.affinity={"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"<label-key>","operator":"In","values":["<label-values>"]}]}]}}}'
 ```
 
 i.e:
-
+To schedule the driver only on nodes labeled with nodepool-type=app or nodepool-type=media, use:
 ```bash
 --set-json 'csiNodeVlzplugin.affinity={"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"nodepool-type","operator":"In","values":["app", "media"]}]}]}}}'
 ```
 
 ### Upgrade
 
-If you had already added this repo earlier, run `helm repo update --force` to retrieve the latest versions of the packages. 
-You can then run `helm search repo volumez-csi` to see the charts.<br/>
+If you previously added this repository, run `helm repo update` to fetch the latest package versions.
+Afterwards, you can run `helm search repo volumez-csi -l` to view the available charts.<br/>
 To upgrade the chart:
   ```bash
-  helm upgrade my-volumez-csi volumez-csi/volumez-csi -n vlz-csi-driver 
+  helm upgrade volumez-csi volumez-csi/volumez-csi -n vlz-csi-driver 
   ```
 
 To upgrade to a specific chart version:
   ```bash
-  helm upgrade my-volumez-csi volumez-csi/volumez-csi -n vlz-csi-driver --version VERSION_TAG
+  helm upgrade volumez-csi volumez-csi/volumez-csi -n vlz-csi-driver --version VERSION_TAG
   ```
 i.e:
   ```bash
-  helm upgrade my-volumez-csi volumez-csi/volumez-csi -n vlz-csi-driver --version 1.23.0-rc.1
+  helm upgrade volumez-csi volumez-csi/volumez-csi -n vlz-csi-driver --version 1.31.0-rc.1
   ```
 
 ### Uninstall
@@ -67,5 +69,5 @@ i.e:
 To uninstall the chart:
 
 ```bash
-helm uninstall my-volumez-csi -n vlz-csi-driver
+helm uninstall volumez-csi -n vlz-csi-driver
 ```

--- a/charts/volumez-csi/README.md
+++ b/charts/volumez-csi/README.md
@@ -1,6 +1,6 @@
 # volumez-csi
 
-![Version: 1.31.0-rc.1](https://img.shields.io/badge/Version-1.31.0--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![Version: 1.31.0](https://img.shields.io/badge/Version-1.31.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
 A Helm chart for Volumez-CSI Driver
 
@@ -12,7 +12,7 @@ A Helm chart for Volumez-CSI Driver
 | vlzAuthToken | string | `""` | CSI Driver Token (Refresh Token) |
 | verboseLevel | int | `0` |  |
 | vlzCsiDriver.repository | string | `"public.ecr.aws/u0q8u2v6/volumez-csi"` |  |
-| vlzCsiDriver.tag | string | `"v1.15.0-rc.1"` |  |
+| vlzCsiDriver.tag | string | `"v1.15.0"` |  |
 | vlzCsiDriver.fsGroupPolicy | string | `"File"` |  |
 | vlzSnapshotRollbackController.repository | string | `"public.ecr.aws/u0q8u2v6/vlz-snapshotrollback-controller"` |  |
 | vlzSnapshotRollbackController.tag | string | `"v1.3.0"` |  |


### PR DESCRIPTION
- Removed the invalid --force flag from the helm repo update command.
- Updated the example release name from my-volumez-csi to volumez-csi for consistency.