### PR TITLE
VLZ-13224 Add extra snapshot metadata

### DIFF
--- a/charts/volumez-csi/templates/statefulset.yaml
+++ b/charts/volumez-csi/templates/statefulset.yaml
@@ -27,6 +27,7 @@ spec:
             - "--timeout=90s"
             - "--retry-interval-start=10s"
             - "--retry-interval-max=40m"
+            - "--extra-create-metadata"
           env:
             - name: ADDRESS
               value: /csi/csi.sock


### PR DESCRIPTION
- Add `--extra-create-metadata` flag to external-snapshotter, it will now give resource metadata on grpc create request.